### PR TITLE
Add 'Open with Codeanywhere' badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,11 @@ https://github.com/clhuang/heroku-buildpack-webp-binaries.git
 
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new?skip_quickstart=true&machine=basicLinux32gb&repo=ReyEndymion/ANI_MX_SCANS-MD&ref=main&geo=UsEast)
 
+----
+### 🌌 **ACTIVAR EN CODEANYWHERE**
+
+[![Open in Codeanywhere](https://codeanywhere.com/img/open-in-codeanywhere-btn.svg)](https://app.codeanywhere.com/#https://github.com/ReyEndymion/ANI_MX_SCANS-MD/blob/3d963fdf3e630c69fe1a66d5f4022b322ca31664/README.md)
+
 ----- 
 ### ⏏️ **ACTIVAR EN KOYEB**
 [![Deploy to Koyeb](https://binbashbanana.github.io/deploy-buttons/buttons/remade/koyeb.svg)](https://app.koyeb.com/deploy?type=git&repository=github.com/ReyEndymion/ANI_MX_SCANS-MD&branch=master&name=ANI_MX_SCANS-MD)


### PR DESCRIPTION
With Codeanywhere, developers and contributors can instantly launch a cloud or local IDE with a pre-configured remote development environment. One can work in the cloud or locally, and it ensures all contributors have acecss to the same, ready to use dev env.